### PR TITLE
Some changes.

### DIFF
--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -79,7 +79,7 @@ bool QMCHamiltonian::get(std::ostream& os) const
  * @param aname name of h
  * @param physical if true, a physical operator
  */
-void QMCHamiltonian::addOperator(std::unique_ptr<OperatorBase> h, const std::string& aname, bool physical)
+void QMCHamiltonian::addOperator(std::unique_ptr<OperatorBase>&& h, const std::string& aname, bool physical)
 {
   //change UpdateMode[PHYSICAL] of h so that cloning can be done correctly
   h->UpdateMode[OperatorBase::PHYSICAL] = physical;

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -66,7 +66,7 @@ public:
   ~QMCHamiltonian();
 
   ///add an operator
-  void addOperator(std::unique_ptr<OperatorBase> h, const std::string& aname, bool physical = true);
+  void addOperator(std::unique_ptr<OperatorBase>&& h, const std::string& aname, bool physical = true);
 
   ///record the name-type pair of an operator
   void addOperatorType(const std::string& name, const std::string& type);

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -211,7 +211,7 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   //  QMCHamiltonian::makeClone
   //  OperatorBase::add2Hamiltonian -> ForceChiesaPBCAA::makeClone
   TrialWaveFunction psi;
-  ForceChiesaPBCAA* clone = dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec, psi).get());
+  std::unique_ptr<ForceChiesaPBCAA> clone(dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec, psi).release()));
   clone->evaluate(elec);
   REQUIRE(clone->addionion == force.addionion);
   REQUIRE(clone->forces_IonIon[0][0] == Approx(-0.0228366));


### PR DESCRIPTION
1. Fix unit test_hamiltonian segmentation fault.
2. Use rvalue as argument

The remaining issue in opt deterministic tests needs to change shared_ptr to pointer used as reference. Probably use reference_wrapper if raw pointers look too awful.