### PR TITLE
Reorder specialized function definitions to appease OMP target compilation

### DIFF
--- a/src/QMCWaveFunctions/ElectronGas/FreeOrbitalT.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/FreeOrbitalT.cpp
@@ -20,63 +20,6 @@
 namespace qmcplusplus
 {
 
-template<class T>
-FreeOrbitalT<T>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart) : SPOSetT<T>(my_name)
-{}
-
-//Explicit template specialization
-template<>
-FreeOrbitalT<float>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart)
-    : SPOSetT<float>(my_name),
-      kvecs(kpts_cart),
-      mink(1), // treat k=0 as special case
-      maxk(kpts_cart.size()),
-      k2neg(maxk)
-{
-  this->OrbitalSetSize = 2 * maxk - 1; // k=0 has no (cos, sin) split, SPOSet member
-  for (int ik = 0; ik < maxk; ik++)
-    k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);
-}
-
-template<>
-FreeOrbitalT<double>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart)
-    : SPOSetT<double>(my_name),
-      kvecs(kpts_cart),
-      mink(1), // treat k=0 as special case
-      maxk(kpts_cart.size()),
-      k2neg(maxk)
-{
-  this->OrbitalSetSize = 2 * maxk - 1; // k=0 has no (cos, sin) split, SPOSet member
-  for (int ik = 0; ik < maxk; ik++)
-    k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);
-}
-
-template<>
-FreeOrbitalT<std::complex<float>>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart)
-    : SPOSetT<std::complex<float>>(my_name),
-      kvecs(kpts_cart),
-      mink(0), // treat k=0 as special case
-      maxk(kpts_cart.size()),
-      k2neg(maxk)
-{
-  this->OrbitalSetSize = maxk; // SPOSet member
-  for (int ik = 0; ik < maxk; ik++)
-    k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);
-}
-
-template<>
-FreeOrbitalT<std::complex<double>>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart)
-    : SPOSetT<std::complex<double>>(my_name),
-      kvecs(kpts_cart),
-      mink(0), // treat k=0 as special case
-      maxk(kpts_cart.size()),
-      k2neg(maxk)
-{
-  this->OrbitalSetSize = maxk; // SPOSet member
-  for (int ik = 0; ik < maxk; ik++)
-    k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);
-}
-
 
 template<class T>
 void FreeOrbitalT<T>::evaluateVGL(const ParticleSet& P,
@@ -694,6 +637,59 @@ void FreeOrbitalT<T>::evaluate_notranspose(const ParticleSet& P,
     ValueVector d2p(d2phi[i], this->OrbitalSetSize);
     evaluateVGL(P, iat, p, dp, d2p);
   }
+}
+
+//Explicit template specialization
+template<>
+FreeOrbitalT<float>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart)
+    : SPOSetT<float>(my_name),
+      kvecs(kpts_cart),
+      mink(1), // treat k=0 as special case
+      maxk(kpts_cart.size()),
+      k2neg(maxk)
+{
+  this->OrbitalSetSize = 2 * maxk - 1; // k=0 has no (cos, sin) split, SPOSet member
+  for (int ik = 0; ik < maxk; ik++)
+    k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);
+}
+
+template<>
+FreeOrbitalT<double>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart)
+    : SPOSetT<double>(my_name),
+      kvecs(kpts_cart),
+      mink(1), // treat k=0 as special case
+      maxk(kpts_cart.size()),
+      k2neg(maxk)
+{
+  this->OrbitalSetSize = 2 * maxk - 1; // k=0 has no (cos, sin) split, SPOSet member
+  for (int ik = 0; ik < maxk; ik++)
+    k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);
+}
+
+template<>
+FreeOrbitalT<std::complex<float>>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart)
+    : SPOSetT<std::complex<float>>(my_name),
+      kvecs(kpts_cart),
+      mink(0), // treat k=0 as special case
+      maxk(kpts_cart.size()),
+      k2neg(maxk)
+{
+  this->OrbitalSetSize = maxk; // SPOSet member
+  for (int ik = 0; ik < maxk; ik++)
+    k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);
+}
+
+template<>
+FreeOrbitalT<std::complex<double>>::FreeOrbitalT(const std::string& my_name, const std::vector<PosType>& kpts_cart)
+    : SPOSetT<std::complex<double>>(my_name),
+      kvecs(kpts_cart),
+      mink(0), // treat k=0 as special case
+      maxk(kpts_cart.size()),
+      k2neg(maxk)
+{
+  this->OrbitalSetSize = maxk; // SPOSet member
+  for (int ik = 0; ik < maxk; ik++)
+    k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);
 }
 
 


### PR DESCRIPTION
## Proposed changes

Fixing compiler error in FreeOrbitalT

## What type(s) of changes does this code introduce?

- Bugfix (I guess)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 22.04, clang-15 with offload target x86_64

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
